### PR TITLE
Cannot upload data.frame containing Boolean

### DIFF
--- a/R/airtabler.R
+++ b/R/airtabler.R
@@ -283,7 +283,7 @@ air_parse <- function(res) {
 #' @export
 air_insert <- function(base, table_name, record_data) {
 
-  if(inherits(record_data, "data.frame")) {
+  if( inherits(record_data, "data.frame")) {
     return( air_insert_data_frame(base, table_name, record_data))
   }
 
@@ -309,7 +309,7 @@ air_insert <- function(base, table_name, record_data) {
 air_insert_data_frame <- function(base, table_name, records) {
   lapply(seq_len(nrow(records)), function(i) {
     record_data <-
-      unlist(as.list(records[i,]), recursive = FALSE)
+      as.list(records[i,])
     air_insert(base = base, table_name = table_name, record_data = record_data)
   })
 }

--- a/R/airtabler.R
+++ b/R/airtabler.R
@@ -341,7 +341,9 @@ air_prepare_record <- function(x) {
     if(inherits(x[[i]], "air_multiple")) {
       class(x[[i]]) <- class(x[[i]])[-1]
     } else {
-      if(length(x[[i]]) == 1 ) {
+      if(is.list(x[[i]])) {
+        x[[i]] <- unlist(x[[i]])
+      } else if(length(x[[i]]) == 1) {
         x[[i]] <- jsonlite::unbox(x[[i]])
       }
     }


### PR DESCRIPTION
Thanks for a very useful package!

I've noticed I can't upload a data.frame containing Boolean columns unless I split it into its rows.

It's because `unlist(as.list(records[i,]), recursive = FALSE)` in `air_insert_data_frame()`  transforms logicals into strings, therefore the subsequent call to `jsonlite::toJSON()` creates JSON that's not valid for the API. Cf example below,

``` r

record_data <- unlist(as.list(tibble::tibble(field1 = TRUE,
                              field2 = "myfield")), recursive = FALSE)

json_record_data <- jsonlite::toJSON(list(fields = record_data))
json_record_data
#> {"fields":["TRUE","myfield"]}

# What I'd want to get

record_data <- as.list(tibble::tibble(field1 = TRUE,
                                      field2 = "myfield"))

json_record_data <- jsonlite::toJSON(list(fields = record_data))
json_record_data
#> {"fields":{"field1":[true],"field2":["myfield"]}}
```

<sup>Created on 2019-01-08 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

The small change in this PR works for me but I have not understood the role `unlist` played with to begin with so might be breaking other things. :wink: