### PR TITLE
Offset was unexposed in air_get()

### DIFF
--- a/R/airtabler.R
+++ b/R/airtabler.R
@@ -258,14 +258,18 @@ air_validate <- function(res) {
 
 air_parse <- function(res) {
   res_obj <- jsonlite::fromJSON(httr::content(res, as = "text"))
-  if(!is.null(res_obj$records)) {
-    res <- res_obj$records
-    if(!is.null(res_obj$offset)) {
-      attr(res, "offset") <- res_obj$offset
-    }
-  } else {
-    res <- res_obj
+
+  # Single entry returned, terminate early: expose all key-value pairs
+  if(is.null(res_obj$records)) { return(res_obj) }
+
+  # Multiple entries returned: expose values under 'records' key
+  res <- res_obj$records
+
+  # Add offset, if available
+  if(!is.null(res_obj$offset)) {
+    attr(res, "offset") <- res_obj$offset
   }
+
   res
 }
 

--- a/R/airtabler.R
+++ b/R/airtabler.R
@@ -89,6 +89,7 @@ air_get <- function(base, table_name, record_id = NULL,
   )
   air_validate(res)      # throws exception (stop) if error
   ret <- air_parse(res)  # returns R object
+  offset <- attr(ret, "offset")
   if(combined_result && is.null(record_id)) {
     # combine ID, Fields and CreatedTime in the same data frame:
     ret <-
@@ -97,6 +98,7 @@ air_get <- function(base, table_name, record_id = NULL,
         stringsAsFactors =FALSE
       )
   }
+  attr(ret, "offset") <- offset  
   ret
 }
 

--- a/R/airtabler.R
+++ b/R/airtabler.R
@@ -269,7 +269,6 @@ air_parse <- function(res) {
   if(!is.null(res_obj$offset)) {
     attr(res, "offset") <- res_obj$offset
   }
-
   res
 }
 

--- a/R/airtabler.R
+++ b/R/airtabler.R
@@ -216,8 +216,8 @@ air_select <- function(
         id = ret$id, ret$fields, createdTime = ret$createdTime,
         stringsAsFactors =FALSE
       )
-    attr(ret, "offset") <- offset
   }
+  attr(ret, "offset") <- offset
   ret
 }
 


### PR DESCRIPTION
I came across `airtabler`, and I think it is a great interface!

I wanted fewer API calls, and quicker turnarounds, I saw that there is `air_get()` function, but sadly that function did not return offset for pagination, though the documentation at https://rdrr.io/github/bergant/airtabler/man/air_get.html, suggests so.

This is my effort making that function work like documented, and consistent with the behavior of `air_select()`.